### PR TITLE
Rework intialization to require GitHub Apps installation ID

### DIFF
--- a/lib/travis/github_apps.rb
+++ b/lib/travis/github_apps.rb
@@ -139,8 +139,8 @@ module Travis
 
     def github_api_conn
       @_github_api_conn ||= Faraday.new(url: @github_api_endpoint) do |f|
-        f.adapter Faraday.default_adapter
         f.response :logger if debug
+        f.adapter Faraday.default_adapter
        end
     end
 

--- a/lib/travis/github_apps.rb
+++ b/lib/travis/github_apps.rb
@@ -139,6 +139,7 @@ module Travis
 
     def github_api_conn
       @_github_api_conn ||= Faraday.new(url: @github_api_endpoint) do |f|
+        f.adapter Faraday.default_adapter
         f.response :logger if debug
        end
     end

--- a/lib/travis/github_apps.rb
+++ b/lib/travis/github_apps.rb
@@ -67,7 +67,6 @@ module Travis
 
         request.headers['Authorization'] = "Token #{access_token}"
         request.headers['Accept']        = accept_header
-        request.response :logger if debug
       end
     end
 
@@ -80,7 +79,6 @@ module Travis
         request.headers['Authorization'] = "Token #{access_token}"
         request.headers['Accept']        = accept_header
         request.body = payload
-        request.response :logger if debug
       end
     end
 
@@ -91,11 +89,6 @@ module Travis
         req.url "/installations/#{installation_id}/access_tokens"
         req.headers['Authorization'] = "Bearer #{authorization_jwt}"
         req.headers['Accept'] = "application/vnd.github.machine-man-preview+json"
-        if debug
-          req.response :logger do |logger|
-            logger.filter(/((?:Bearer|Token) )[^"]/,'\1[REDACTED]')
-          end
-        end
       end
 
       # We probably want to do something different than `raise` here but I don't
@@ -145,7 +138,9 @@ module Travis
     end
 
     def github_api_conn
-      @_github_api_conn ||= Faraday.new(url: @github_api_endpoint)
+      @_github_api_conn ||= Faraday.new(url: @github_api_endpoint) do |f|
+        f.response :logger if debug
+       end
     end
 
     def cache_key_for_access_token

--- a/lib/travis/github_apps/version.rb
+++ b/lib/travis/github_apps/version.rb
@@ -1,5 +1,5 @@
 module Travis
   class GithubApps
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/travis-github_apps.gemspec
+++ b/travis-github_apps.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 3.2"
   spec.add_dependency "jwt"
   spec.add_dependency "redis"
+  spec.add_dependency "faraday"
 end


### PR DESCRIPTION
1. Since our library is going to work with exactly on GitHub Apps
   installation, it makes sense to require the installation ID when
   instantiating it.
   This way, we need not pass it around when making HTTP calls.

2. Change the way we handle the `Authorization` header:

* Use `Bearer *` only when fetching the access token with our JWT
* Use `Authorization *` otherwise

3. Explicitly require Faraday, and use Faraday's Test adapter for
   specs

4. For POST requests, allow optional payloads