### PR TITLE
Follow redirects with Faraday

### DIFF
--- a/lib/travis/github_apps.rb
+++ b/lib/travis/github_apps.rb
@@ -153,6 +153,7 @@ module Travis
     def github_api_conn
       @_github_api_conn ||= Faraday.new(url: @github_api_endpoint) do |f|
         f.response :logger if debug
+        f.use FaradayMiddleware::FollowRedirects, limit: 5
         f.adapter Faraday.default_adapter
        end
     end

--- a/lib/travis/github_apps.rb
+++ b/lib/travis/github_apps.rb
@@ -154,6 +154,7 @@ module Travis
       @_github_api_conn ||= Faraday.new(url: @github_api_endpoint) do |f|
         f.response :logger if debug
         f.use FaradayMiddleware::FollowRedirects, limit: 5
+        f.request :retry
         f.adapter Faraday.default_adapter
        end
     end


### PR DESCRIPTION
Repositories may be renamed in the past, and GitHub might respond
with 301 instead of 2xx.