### PR TITLE
Fix access token URL

### DIFF
--- a/lib/travis/github_apps.rb
+++ b/lib/travis/github_apps.rb
@@ -104,7 +104,7 @@ module Travis
 
     def fetch_new_access_token
       response = github_api_conn.post do |req|
-        req.url "/apps/installations/#{installation_id}/access_tokens"
+        req.url "/app/installations/#{installation_id}/access_tokens"
         req.headers['Authorization'] = "Bearer #{authorization_jwt}"
         req.headers['Accept'] = "application/vnd.github.machine-man-preview+json"
       end

--- a/lib/travis/github_apps.rb
+++ b/lib/travis/github_apps.rb
@@ -13,7 +13,7 @@ module Travis
     # Access token is the "Installation Access Token" required to authenticate
     #   this application against the GitHub Apps API.
     #
-    # https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-an-installation
+    # https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/
     #
 
     # GitHub allows JWT token to be valid up to 10 minutes.

--- a/spec/travis/github_apps_spec.rb
+++ b/spec/travis/github_apps_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe Travis::GithubApps do
     let(:conn) {
       Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.post("/apps/installations/12345/access_tokens") { |env| [201, {}, "{\"token\":\"github_apps_access_token\",\"expires_at\":\"2018-04-03T20:52:14Z\"}"] }
-          stub.post("/apps/installations/23456/access_tokens") { |env| [404, {}, ""] }
+          stub.post("/app/installations/12345/access_tokens") { |env| [201, {}, "{\"token\":\"github_apps_access_token\",\"expires_at\":\"2018-04-03T20:52:14Z\"}"] }
+          stub.post("/app/installations/23456/access_tokens") { |env| [404, {}, ""] }
         end
       end
     }


### PR DESCRIPTION
Redo https://github.com/travis-ci/travis-github_apps/pull/14, but with correct URL.