### PR TITLE
full relative path to api

### DIFF
--- a/lib/travis/github_apps.rb
+++ b/lib/travis/github_apps.rb
@@ -104,7 +104,7 @@ module Travis
 
     def fetch_new_access_token
       response = github_api_conn.post do |req|
-        req.url "/app/installations/#{installation_id}/access_tokens"
+        req.url "app/installations/#{installation_id}/access_tokens"
         req.headers['Authorization'] = "Bearer #{authorization_jwt}"
         req.headers['Accept'] = "application/vnd.github.machine-man-preview+json"
       end


### PR DESCRIPTION
If you use the leading slash, it means an absolute path, i.e. "discard whatever path is configured by the URL prefix of this connection". Github enterprise uses /api/v3/